### PR TITLE
feat: Implement data fetching and rendering in React components

### DIFF
--- a/apps/mvvm-react/src/components/GreenhouseList.tsx
+++ b/apps/mvvm-react/src/components/GreenhouseList.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { greenHouseViewModel } from "@repo/view-models/GreenHouseViewModel";
 import { useObservable } from "../hooks/useObservable";
 
@@ -5,9 +6,24 @@ export function GreenhouseList() {
   const greenHouses = useObservable(greenHouseViewModel.data$, []);
   console.log("GreenHouse data updated:", greenHouses);
 
+  useEffect(() => {
+    greenHouseViewModel.fetchCommand.execute();
+  }, []);
+
   return (
     <div>
       <h1>Greenhouses</h1>
+      {greenHouses && greenHouses.length > 0 ? (
+        <ul>
+          {greenHouses.map((gh) => (
+            <li key={gh.id}>
+              {gh.name} (ID: {gh.id})
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No greenhouses found or still loading...</p>
+      )}
     </div>
   );
 }

--- a/apps/mvvm-react/src/components/SensorList.tsx
+++ b/apps/mvvm-react/src/components/SensorList.tsx
@@ -16,8 +16,8 @@ export function SensorList() {
       {sensors && sensors.length > 0 ? (
         <ul>
           {sensors.map((sensor) => (
-            <li key={sensor.id}>
-              {sensor.name} (ID: {sensor.id})
+            <li key={sensor.greenhouseId}>
+              {sensor.type} (Status: {sensor.status})
             </li>
           ))}
         </ul>

--- a/apps/mvvm-react/src/components/SensorList.tsx
+++ b/apps/mvvm-react/src/components/SensorList.tsx
@@ -1,13 +1,29 @@
+import { useEffect } from "react";
 import { sensorViewModel } from "@repo/view-models/SensorViewModel";
 import { useObservable } from "../hooks/useObservable";
 
 export function SensorList() {
   const sensors = useObservable(sensorViewModel.data$, []);
-  console.log("sensors data updated:", sensors);
+  console.log("Sensors data updated:", sensors);
+
+  useEffect(() => {
+    sensorViewModel.fetchCommand.execute();
+  }, []);
 
   return (
     <div>
-      <h1>sensors</h1>
+      <h1>Sensors</h1>
+      {sensors && sensors.length > 0 ? (
+        <ul>
+          {sensors.map((sensor) => (
+            <li key={sensor.id}>
+              {sensor.name} (ID: {sensor.id})
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No sensors found or still loading...</p>
+      )}
     </div>
   );
 }

--- a/apps/mvvm-react/src/components/SensorReadingList.tsx
+++ b/apps/mvvm-react/src/components/SensorReadingList.tsx
@@ -1,13 +1,30 @@
+import { useEffect } from "react";
 import { sensorReadingViewModel } from "@repo/view-models/SensorReadingViewModel";
 import { useObservable } from "../hooks/useObservable";
 
 export function SensorReadingList() {
   const readingList = useObservable(sensorReadingViewModel.data$, []);
-  console.log("readingList data updated:", readingList);
+  console.log("SensorReadingList data updated:", readingList);
+
+  useEffect(() => {
+    sensorReadingViewModel.fetchCommand.execute();
+  }, []);
 
   return (
     <div>
-      <h1>readingList</h1>
+      <h1>Sensor Readings</h1>
+      {readingList && readingList.length > 0 ? (
+        <ul>
+          {readingList.map((reading) => (
+            <li key={reading.id}>
+              Reading ID: {reading.id}, Sensor ID: {reading.sensorId}, Timestamp:{" "}
+              {new Date(reading.timestamp).toLocaleString()}, Value: {reading.value}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No sensor readings found or still loading...</p>
+      )}
     </div>
   );
 }

--- a/apps/mvvm-react/src/components/SensorReadingList.tsx
+++ b/apps/mvvm-react/src/components/SensorReadingList.tsx
@@ -16,9 +16,10 @@ export function SensorReadingList() {
       {readingList && readingList.length > 0 ? (
         <ul>
           {readingList.map((reading) => (
-            <li key={reading.id}>
-              Reading ID: {reading.id}, Sensor ID: {reading.sensorId}, Timestamp:{" "}
-              {new Date(reading.timestamp).toLocaleString()}, Value: {reading.value}
+            <li key={reading.sensorId}>
+              Reading ID: {reading.sensorId}, Sensor ID: {reading.sensorId},
+              Timestamp: {new Date(reading.timestamp).toLocaleString()}, Value:{" "}
+              {reading.value}
             </li>
           ))}
         </ul>

--- a/apps/mvvm-react/src/components/ThresholdAlertList.tsx
+++ b/apps/mvvm-react/src/components/ThresholdAlertList.tsx
@@ -17,8 +17,8 @@ export function ThresholdAlertList() {
         <ul>
           {thresholds.map((alert) => (
             <li key={alert.id}>
-              Alert ID: {alert.id}, Sensor ID: {alert.sensorId}, Message:{" "}
-              {alert.message}, Timestamp: {new Date(alert.timestamp).toLocaleString()}
+              Alert ID: {alert.id}, Sensor ID: {alert.sensorType}, Message: Max:{" "}
+              {alert.maxValue}, Min: {alert.minValue}
             </li>
           ))}
         </ul>

--- a/apps/mvvm-react/src/components/ThresholdAlertList.tsx
+++ b/apps/mvvm-react/src/components/ThresholdAlertList.tsx
@@ -1,13 +1,30 @@
+import { useEffect } from "react";
 import { thresholdAlertViewModel } from "@repo/view-models/ThresholdAlertViewModel";
 import { useObservable } from "../hooks/useObservable";
 
 export function ThresholdAlertList() {
   const thresholds = useObservable(thresholdAlertViewModel.data$, []);
-  console.log("thresholds data updated:", thresholds);
+  console.log("ThresholdAlertList data updated:", thresholds);
+
+  useEffect(() => {
+    thresholdAlertViewModel.fetchCommand.execute();
+  }, []);
 
   return (
     <div>
-      <h1>thresholds</h1>
+      <h1>Threshold Alerts</h1>
+      {thresholds && thresholds.length > 0 ? (
+        <ul>
+          {thresholds.map((alert) => (
+            <li key={alert.id}>
+              Alert ID: {alert.id}, Sensor ID: {alert.sensorId}, Message:{" "}
+              {alert.message}, Timestamp: {new Date(alert.timestamp).toLocaleString()}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No threshold alerts found or still loading...</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This commit enables the GreenhouseList, SensorList, SensorReadingList, and ThresholdAlertList components to fetch data from their respective view models and render it.

Key changes:
- Modified each React component to call the `fetchCommand.execute()` method on its view model when the component mounts using the `useEffect` hook.
- Updated the JSX in each component to map over the fetched data (observed via `useObservable`) and display relevant properties for each item in a list format.
- Added conditional rendering to display a loading/empty message if data is not yet available.
- Confirmed that `fetchCommand` is already public in all relevant view models as it's inherited from the base `RestfulApiViewModel` class, so no changes were needed in the view model files themselves for this functionality.